### PR TITLE
Show dataset columns

### DIFF
--- a/get-data.js
+++ b/get-data.js
@@ -8,14 +8,26 @@ export async function getData(fileName) {
       return response.text();
     })
     .then((data) => {
-      const rows = data
-        .split("\n")
+      const lines = data.trim().split("\n");
+      const headers = lines[0].split(",");
+      const rows = lines
         .slice(1)
         .map((row) => row.split(",").map(Number));
-      return rows;
+      return { data: rows, headers };
     })
     .catch((error) => {
       console.error("Error fetching data:", error);
       throw error;
     });
+}
+
+export async function getColumns(fileName) {
+  const path = `./data/${fileName}.csv`;
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  const text = await response.text();
+  const firstLine = text.split("\n")[0].trim();
+  return firstLine.split(",");
 }

--- a/index.html
+++ b/index.html
@@ -30,7 +30,17 @@
     <label>Iterations: <input id="iterations" type="number" value="100"></label>
     <button id="runButton">Run</button>
   </div>
+  <p id="columns-display"></p>
   <canvas id="costChart" width="600" height="400"></canvas>
+  <section id="test-section" style="display:none">
+    <h2>Test the Model</h2>
+    <p id="feature-list"></p>
+    <label>Input features (comma separated):
+      <input id="test-input" type="text" />
+    </label>
+    <button id="testButton">Predict</button>
+    <p id="predictionOutput"></p>
+  </section>
   <script src="./node_modules/chart.js/dist/chart.umd.min.js"></script>
   <script type="module" src="./app.js"></script>
   <script type="module" src="./get-data.js"></script>

--- a/normalize.js
+++ b/normalize.js
@@ -10,7 +10,9 @@ export function normalizeFeatures(X) {
     }
   }
 
-  return X.map((row) =>
+  const normalized = X.map((row) =>
     row.map((val, j) => (val - mins[j]) / (maxs[j] - mins[j]))
   );
+
+  return { normalized, mins, maxs };
 }

--- a/styles.css
+++ b/styles.css
@@ -29,3 +29,13 @@ input {
 button {
   margin-left: 10px;
 }
+
+#columns-display {
+  margin-bottom: 10px;
+  font-weight: bold;
+}
+
+#feature-list {
+  margin-bottom: 10px;
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
- fetch header names from CSV files
- display selected dataset's columns and feature names in the UI
- hook dataset dropdown to update column list
- keep feature list visible for predictions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68526bdcf458832c9b3130bd1077a745